### PR TITLE
Refactor CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,6 @@ target_link_libraries(
     ${extra_libs}
 )
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(gcc "$<COMPILE_LANG_AND_ID:CXX,GNU>")
 set(clang "$<COMPILE_LANG_AND_ID:CXX,Clang>")
 set(msvc "$<COMPILE_LANG_AND_ID:CXX,MSVC>")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,7 +14,7 @@
       "generator": "Ninja"
     },
     {
-      "name": "local",
+      "name": "test_local",
       "inherits": ["test"],
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,8 +11,8 @@ target_compile_options(
   mvPolynomial_test
   INTERFACE
     # Common options for gcc and clang
-    "$<${gcc_like}>:-Wall;-Wextra>"
-    "$<${msvc}:/Wall>"
+    "$<${gcc_like}:-Wall;-Wextra;-Werror>"
+    "$<${msvc}:/Wall;/WX>"
 )
 target_link_libraries(
   mvPolynomial_test


### PR DESCRIPTION
I did the following:

- Make CMAKE_EXPORT_COMPILE_COMMANDS off.
- Rename "local" preset.
- Add -Werror for gcc and clang and /WX for msvc.